### PR TITLE
Added SPF Helper Tool to SPF Guide

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -133,7 +133,7 @@
   <!----------------------------------------------
   SPF Tool
   ---------------------------------------------->
-  <div class="spf-tool">
+  <div class="spf-tool" aria-role="widget">
 
     <!---------------------
     Start
@@ -141,7 +141,7 @@
     <div class="spf-tool_pane spf-tool_pane--start spf-tool_pane--visible">
       <h2 class="spf-tool_title">Ready to get started?</h2>
       <form action="#" method="post" class="spf-tool_form">
-        <label for="spf_domain" class="spf-tool_label">Enter your domain name and we’ll check your DNS records to see if you need to set up SPF.</label>
+        <label for="spf_domain" class="spf-tool_label">Enter your domain name and we’ll check your DNS records to see if you need to set up an SPF policy.</label>
         <input type="text" id="spf_domain" class="spf-tool_input" placeholder="your-awesome-domain.com" />
         <button type="submit" class="cta-btn cta-btn--default spf-tool_submit">Check DNS</button>
       </form>
@@ -151,7 +151,7 @@
     <!---------------------
     Add New Record
     ---------------------->
-    <div class="spf-tool_pane spf-tool_pane--create">
+    <div class="spf-tool_pane spf-tool_pane--create" aria-hidden="true">
       <h2 class="spf-tool_title">Add an SPF Policy</h2>
       <p>Looks like you don’t have an SPF TXT record set up on your domain yet.</p>
       <p class="spf-tool_instruction">Create a new TXT record with the following value:</p>
@@ -164,7 +164,7 @@
     <!---------------------
     Update Existing Record
     ---------------------->
-    <div class="spf-tool_pane spf-tool_pane--modify">
+    <div class="spf-tool_pane spf-tool_pane--modify" aria-hidden="true">
       <h2 class="spf-tool_title">Update Your SPF Policy</h2>
       <p>Good news! You already have an SPF TXT record set up so you’ll just need to make a few changes.</p>
       <p class="spf-tool_instruction">Update your existing SPF TXT record with the following:</p>
@@ -177,7 +177,7 @@
     <!---------------------
     Already set up
     ---------------------->
-    <div class="spf-tool_pane spf-tool_pane--existing">
+    <div class="spf-tool_pane spf-tool_pane--existing" aria-hidden="true">
       <h2 class="spf-tool_title">You’re all set!</h2>
       <p>Postmark is already specified in your SPF policy so you don’t need to make any changes. How about checking out some of our <a href="https://postmarkapp.com/guides">other guides</a>.</p>
 

--- a/html/index.html
+++ b/html/index.html
@@ -147,19 +147,17 @@
       </form>
     </div>
 
-    <!---------------------
-    Loading
-    ---------------------->
-    <div class="spf-tool_pane spf-tool_pane--loading">
-      <h2 class="spf-tool_title">Sit tight while we check your domains DNS records...</h2>
-    </div>
-
 
     <!---------------------
     Add New Record
     ---------------------->
     <div class="spf-tool_pane spf-tool_pane--create">
-      Create the record
+      <h2 class="spf-tool_title">Add an SPF Policy</h2>
+      <p>Looks like you don’t have an SPF TXT record set up on your domain yet.</p>
+      <p class="spf-tool_instruction">Create a new TXT record with the following value:</p>
+      <pre class="spf-tool_code"><code></code></pre>
+
+      <a href="#" class="cta-btn spf-tool_email">Email this to a friend</a> <a href="#" class="spf-tool_restart">Test another domain</a>
     </div>
 
 
@@ -167,7 +165,12 @@
     Update Existing Record
     ---------------------->
     <div class="spf-tool_pane spf-tool_pane--modify">
-      Modify
+      <h2 class="spf-tool_title">Update Your SPF Policy</h2>
+      <p>Good news! You already have an SPF TXT record set up so you’ll just need to make a few changes.</p>
+      <p class="spf-tool_instruction">Update your existing SPF TXT record with the following:</p>
+      <pre class="spf-tool_code"><code></code></pre>
+
+      <a href="#" class="cta-btn spf-tool_email">Email this to a friend</a> <a href="#" class="spf-tool_restart">Test another domain</a>
     </div>
 
 
@@ -175,9 +178,12 @@
     Already set up
     ---------------------->
     <div class="spf-tool_pane spf-tool_pane--existing">
-      Existing record
+      <h2 class="spf-tool_title">You’re all set!</h2>
+      <p>Postmark is already specified in your SPF policy so you don’t need to make any changes. How about checking out some of our <a href="https://postmarkapp.com/guides">other guides</a>.</p>
+
+      <a href="#" class="spf-tool_restart">Test another domain</a>
     </div>
-    
+
 
   </div>
 

--- a/html/index.html
+++ b/html/index.html
@@ -131,6 +131,57 @@
 
 
   <!----------------------------------------------
+  SPF Tool
+  ---------------------------------------------->
+  <div class="spf-tool">
+
+    <!---------------------
+    Start
+    ---------------------->
+    <div class="spf-tool_pane spf-tool_pane--start spf-tool_pane--visible">
+      <h2 class="spf-tool_title">Ready to get started?</h2>
+      <form action="#" method="post" class="spf-tool_form">
+        <label for="spf_domain" class="spf-tool_label">Enter your domain name and we’ll check your DNS records to see if you need to set up SPF.</label>
+        <input type="text" id="spf_domain" class="spf-tool_input" placeholder="your-awesome-domain.com" />
+        <button type="submit" class="cta-btn cta-btn--default spf-tool_submit">Check DNS</button>
+      </form>
+    </div>
+
+    <!---------------------
+    Loading
+    ---------------------->
+    <div class="spf-tool_pane spf-tool_pane--loading">
+      <h2 class="spf-tool_title">Sit tight while we check your domains DNS records...</h2>
+    </div>
+
+
+    <!---------------------
+    Add New Record
+    ---------------------->
+    <div class="spf-tool_pane spf-tool_pane--create">
+      Create the record
+    </div>
+
+
+    <!---------------------
+    Update Existing Record
+    ---------------------->
+    <div class="spf-tool_pane spf-tool_pane--modify">
+      Modify
+    </div>
+
+
+    <!---------------------
+    Already set up
+    ---------------------->
+    <div class="spf-tool_pane spf-tool_pane--existing">
+      Existing record
+    </div>
+    
+
+  </div>
+
+  <!----------------------------------------------
   Guide navigation
   ---------------------------------------------->
   <div class="u-container">

--- a/html/javascripts/landing.js
+++ b/html/javascripts/landing.js
@@ -211,9 +211,11 @@ var SpfTool = {
   showPane: function(pane) {
     Array.prototype.forEach.call(this.panes, function(ele) {
       if (ele.classList.contains('spf-tool_pane--' + pane)) {
+        ele.removeAttribute('aria-hidden');
         return ele.classList.add('spf-tool_pane--visible');
       }
 
+      ele.setAttribute('aria-hidden', 'true');
       return ele.classList.remove('spf-tool_pane--visible');
     });
   },

--- a/html/javascripts/landing.js
+++ b/html/javascripts/landing.js
@@ -159,3 +159,135 @@ window.addEventListener('DOMContentLoaded', function () {
 }, false);
 
 /* ----------------- Write your code here ---------------- */
+
+const DNS_ENDPOINT = 'https://tranquil-stream-29919.herokuapp.com/update-spf';
+const SERVICE_SPF = 'spf.mtasv.net';
+
+var SpfTool = {
+
+  panes: null,
+
+
+  /**
+   * Initialise the SPF tool.
+   *
+   * @return {undefined}
+   */
+  init: function() {
+    // Find the panes.
+    this.panes = document.querySelectorAll('.spf-tool_pane');
+
+    // Setup Event Listeners
+    document.querySelector('.spf-tool_form').addEventListener('submit', this.checkSpfRecord);
+  },
+
+
+  /**
+   * Display a pane.
+   *
+   * @param  {String} pane The target pane.
+   * @return {undefined}
+   */
+  showPane: function(pane) {
+    Array.prototype.forEach.call(this.panes, function(ele) {
+      if (ele.classList.contains('spf-tool_pane--' + pane)) {
+        return ele.classList.add('spf-tool_pane--visible');
+      }
+
+      return ele.classList.remove('spf-tool_pane--visible');
+    });
+  },
+
+  /**.
+   * Check the DNS records to see if an SPF record needs to be added or
+   * modified.
+   *
+   * This hits a simple node service I built:
+   * https://github.com/matt-west/spf-web-service
+   *
+   * @param {Event} event   The form submission event.
+   * @return {undefined}
+   */
+  checkSpfRecord: function(event) {
+    event.preventDefault();
+
+    var domain = document.querySelector('.spf-tool_input').value;
+
+    // Basic input validation
+    if (!domain || !domain.replace(/\s/g, '').length) {
+      alert('Please specify a domain name'); // TODO: Display validation message.
+      return;
+    }
+
+    // Show a loading state.
+    SpfTool.showPane('loading');
+
+    // Make a requet to check the DNS.
+    var request = new XMLHttpRequest();
+
+    request.addEventListener('load', SpfTool.handleApiSuccess);
+    request.addEventListener('error', SpfTool.handleApiError);
+    request.addEventListener('abort', SpfTool.handleApiError);
+
+    request.open('POST', DNS_ENDPOINT);
+    request.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+    request.send(JSON.stringify({
+      domain: domain,
+      service_spf: SERVICE_SPF
+    }));
+
+  },
+
+  /**
+   * Handle successful requests to the API.
+   *
+   * @return {undefined}
+   */
+  handleApiSuccess: function() {
+    var result = JSON.parse(this.responseText);
+
+    if (this.status !== 200) {
+      SpfTool.showErrors(result.errors);
+      return;
+    }
+
+    var result = JSON.parse(this.responseText);
+
+    switch(result.operation) {
+      case 'create':
+
+        break;
+      case 'modify':
+
+        break;
+      case 'existing':
+
+        break;
+    }
+
+  },
+
+  /**
+   * Handle requests to the API that err.
+   *
+   * @return {undefined}
+   */
+  handleApiError: function() {
+    var result = JSON.parse(this.responseText);
+    SpfTool.showErrors(result.errors);
+  },
+
+  /**
+   * Display API errors to the user.
+   *
+   * @param  {Array} errors  A collection of error messages.
+   * @return {undefined}
+   */
+  showErrors: function(errors) {
+    console.log(errors);
+    SpfTool.showPane('start');
+  }
+
+};
+
+SpfTool.init();

--- a/html/javascripts/landing.js
+++ b/html/javascripts/landing.js
@@ -226,6 +226,7 @@ var SpfTool = {
     event.preventDefault();
 
     document.querySelector('.spf-tool_submit').setAttribute('disabled', 'disabled');
+    document.querySelector('.spf-tool_input').setAttribute('disabled', 'disabled');
 
     // Remove any errors.
     if (document.querySelector('.spf-tool_errors')) {
@@ -247,8 +248,6 @@ var SpfTool = {
       domain: domain,
       service_spf: SERVICE_SPF
     }));
-
-    document.querySelector('.spf-tool_input').value = '';
   },
 
   /**
@@ -258,6 +257,8 @@ var SpfTool = {
    */
   handleApiSuccess: function() {
     document.querySelector('.spf-tool_submit').removeAttribute('disabled');
+    document.querySelector('.spf-tool_input').removeAttribute('disabled');
+    document.querySelector('.spf-tool_input').value = '';
 
     var result = JSON.parse(this.responseText);
 
@@ -276,6 +277,7 @@ var SpfTool = {
    */
   handleApiError: function() {
     document.querySelector('.spf-tool_submit').removeAttribute('disabled');
+    document.querySelector('.spf-tool_input').removeAttribute('disabled');
 
     var result = JSON.parse(this.responseText);
     SpfTool.showErrors(result.errors);

--- a/html/javascripts/landing.js
+++ b/html/javascripts/landing.js
@@ -166,6 +166,9 @@ const SERVICE_SPF = 'spf.mtasv.net';
 var SpfTool = {
 
   panes: null,
+  form: null,
+  submitBtn: null,
+  input: null,
 
   /**
    * Initialise the SPF tool.
@@ -173,11 +176,14 @@ var SpfTool = {
    * @return {undefined}
    */
   init: function() {
-    // Find the panes.
+    // Find the key elements.
     this.panes = document.querySelectorAll('.spf-tool_pane');
+    this.form = document.querySelector('.spf-tool_form');
+    this.submitBtn = document.querySelector('.spf-tool_submit');
+    this.domainInput = document.querySelector('.spf-tool_input');
 
     // Setup Event Listeners
-    document.querySelector('.spf-tool_form').addEventListener('submit', this.checkSpfRecord);
+    this.form.addEventListener('submit', this.checkSpfRecord);
 
     Array.prototype.forEach.call(document.querySelectorAll('.spf-tool_restart'), function(link) {
       link.addEventListener('click', SpfTool.resetTool);
@@ -225,15 +231,16 @@ var SpfTool = {
   checkSpfRecord: function(event) {
     event.preventDefault();
 
-    document.querySelector('.spf-tool_submit').setAttribute('disabled', 'disabled');
-    document.querySelector('.spf-tool_input').setAttribute('disabled', 'disabled');
+    SpfTool.submitBtn.setAttribute('disabled', 'disabled');
+    SpfTool.domainInput.setAttribute('disabled', 'disabled');
 
     // Remove any errors.
-    if (document.querySelector('.spf-tool_errors')) {
-      document.querySelector('.spf-tool_errors').remove();
+    var errorsContainer = document.querySelector('.spf-tool_errors');
+    if (errorsContainer) {
+      errorsContainer.remove();
     }
 
-    var domain = document.querySelector('.spf-tool_input').value;
+    var domain = SpfTool.domainInput.value;
 
     // Make a request to check the DNS.
     var request = new XMLHttpRequest();
@@ -256,9 +263,9 @@ var SpfTool = {
    * @return {undefined}
    */
   handleApiSuccess: function() {
-    document.querySelector('.spf-tool_submit').removeAttribute('disabled');
-    document.querySelector('.spf-tool_input').removeAttribute('disabled');
-    document.querySelector('.spf-tool_input').value = '';
+    SpfTool.submitBtn.removeAttribute('disabled');
+    SpfTool.domainInput.removeAttribute('disabled');
+    SpfTool.domainInput.value = '';
 
     var result = JSON.parse(this.responseText);
 
@@ -276,8 +283,8 @@ var SpfTool = {
    * @return {undefined}
    */
   handleApiError: function() {
-    document.querySelector('.spf-tool_submit').removeAttribute('disabled');
-    document.querySelector('.spf-tool_input').removeAttribute('disabled');
+    SpfTool.submitBtn.removeAttribute('disabled');
+    SpfTool.domainInput.removeAttribute('disabled');
 
     var result = JSON.parse(this.responseText);
     SpfTool.showErrors(result.errors);
@@ -290,9 +297,7 @@ var SpfTool = {
    * @return {undefined}
    */
   showErrors: function(errors) {
-    var errorsContainer = document.querySelector('.spf-tool_errors'),
-        form = document.querySelector('.spf-tool_form'),
-        input = document.querySelector('.spf-tool_input');
+    var errorsContainer = document.querySelector('.spf-tool_errors');
 
     if (errorsContainer) {
       errorsContainer.remove();
@@ -307,7 +312,7 @@ var SpfTool = {
       errorList.appendChild(item);
     });
 
-    form.insertBefore(errorList, input);
+    SpfTool.form.insertBefore(errorList, SpfTool.domainInput);
 
     SpfTool.showPane('start');
   },

--- a/html/javascripts/landing.js
+++ b/html/javascripts/landing.js
@@ -167,7 +167,6 @@ var SpfTool = {
 
   panes: null,
 
-
   /**
    * Initialise the SPF tool.
    *
@@ -179,8 +178,23 @@ var SpfTool = {
 
     // Setup Event Listeners
     document.querySelector('.spf-tool_form').addEventListener('submit', this.checkSpfRecord);
+
+    Array.prototype.forEach.call(document.querySelectorAll('.spf-tool_restart'), function(link) {
+      link.addEventListener('click', SpfTool.resetTool);
+    });
   },
 
+  /**
+   * Reset the tool content and return to the satrt page.
+   *
+   * @param {Event} event Click event.
+   */
+  resetTool: function(event) {
+    event.preventDefault();
+
+    SpfTool.result = null;
+    SpfTool.showPane('start');
+  },
 
   /**
    * Display a pane.
@@ -211,18 +225,16 @@ var SpfTool = {
   checkSpfRecord: function(event) {
     event.preventDefault();
 
-    var domain = document.querySelector('.spf-tool_input').value;
+    document.querySelector('.spf-tool_submit').setAttribute('disabled', 'disabled');
 
-    // Basic input validation
-    if (!domain || !domain.replace(/\s/g, '').length) {
-      alert('Please specify a domain name'); // TODO: Display validation message.
-      return;
+    // Remove any errors.
+    if (document.querySelector('.spf-tool_errors')) {
+      document.querySelector('.spf-tool_errors').remove();
     }
 
-    // Show a loading state.
-    SpfTool.showPane('loading');
+    var domain = document.querySelector('.spf-tool_input').value;
 
-    // Make a requet to check the DNS.
+    // Make a request to check the DNS.
     var request = new XMLHttpRequest();
 
     request.addEventListener('load', SpfTool.handleApiSuccess);
@@ -236,6 +248,7 @@ var SpfTool = {
       service_spf: SERVICE_SPF
     }));
 
+    document.querySelector('.spf-tool_input').value = '';
   },
 
   /**
@@ -244,6 +257,8 @@ var SpfTool = {
    * @return {undefined}
    */
   handleApiSuccess: function() {
+    document.querySelector('.spf-tool_submit').removeAttribute('disabled');
+
     var result = JSON.parse(this.responseText);
 
     if (this.status !== 200) {
@@ -251,20 +266,7 @@ var SpfTool = {
       return;
     }
 
-    var result = JSON.parse(this.responseText);
-
-    switch(result.operation) {
-      case 'create':
-
-        break;
-      case 'modify':
-
-        break;
-      case 'existing':
-
-        break;
-    }
-
+    SpfTool.displayResult(result);
   },
 
   /**
@@ -273,6 +275,8 @@ var SpfTool = {
    * @return {undefined}
    */
   handleApiError: function() {
+    document.querySelector('.spf-tool_submit').removeAttribute('disabled');
+
     var result = JSON.parse(this.responseText);
     SpfTool.showErrors(result.errors);
   },
@@ -284,8 +288,75 @@ var SpfTool = {
    * @return {undefined}
    */
   showErrors: function(errors) {
-    console.log(errors);
+    var errorsContainer = document.querySelector('.spf-tool_errors'),
+        form = document.querySelector('.spf-tool_form'),
+        input = document.querySelector('.spf-tool_input');
+
+    if (errorsContainer) {
+      errorsContainer.remove();
+    }
+
+    var errorList = document.createElement('ul');
+    errorList.classList.add('spf-tool_errors');
+
+    Array.prototype.forEach.call(errors, function(error) {
+      var item = document.createElement('li');
+      item.innerText = error;
+      errorList.appendChild(item);
+    });
+
+    form.insertBefore(errorList, input);
+
     SpfTool.showPane('start');
+  },
+
+  /**
+   * Display the result to the user.
+   *
+   * @param  {Object} result The object returned by the API call.
+   * @return {undefined}
+   */
+  displayResult: function(result) {
+    if (result.operation === 'create' || result.operation === 'modify') {
+      // Set code block content.
+      var codeBlock = document.querySelector('.spf-tool_pane--' + result.operation + ' .spf-tool_code code');
+      codeBlock.innerText = result.record;
+
+      // Set email link.
+      var emailLink = document.querySelector('.spf-tool_pane--' + result.operation + ' .spf-tool_email');
+      emailLink.href = SpfTool.generateEmailString(result.operation, result.record, result.domain);
+    }
+
+    SpfTool.showPane(result.operation);
+  },
+
+  /**
+   * Generate the email link.
+   *
+   * @param  {String} operation
+   * @param  {String} record
+   * @param  {String} domain
+   * @return {String}
+   */
+  generateEmailString: function(operation, record, domain) {
+    var subject;
+
+    var body = 'Hello!\n\n';
+    body += 'Can you please update the DNS records for ' + domain + '\n\n';
+
+    if (operation === 'create') {
+      subject = 'Create an SPF policy for ' + domain;
+      body += 'We need to add the following TXT record to define the SPF policy for the domain:\n';
+    } else if (operation === 'modify') {
+      subject = 'Update the SPF policy for ' + domain;
+      body += 'We need to update the SPF TXT record on the domain to:\n';
+    }
+
+    body += record + '\n\n';
+    body += 'You can find more information about SPF policies here: https://postmarkapp.com/guides/spf\n\n';
+    body += 'Thank you!';
+
+    return 'mailto:?subject=' + encodeURI(subject) + '&body=' + encodeURI(body);
   }
 
 };

--- a/html/src/javascripts/WORK_HERE.js
+++ b/html/src/javascripts/WORK_HERE.js
@@ -6,6 +6,9 @@ const SERVICE_SPF = 'spf.mtasv.net';
 var SpfTool = {
 
   panes: null,
+  form: null,
+  submitBtn: null,
+  input: null,
 
   /**
    * Initialise the SPF tool.
@@ -13,11 +16,14 @@ var SpfTool = {
    * @return {undefined}
    */
   init: function() {
-    // Find the panes.
+    // Find the key elements.
     this.panes = document.querySelectorAll('.spf-tool_pane');
+    this.form = document.querySelector('.spf-tool_form');
+    this.submitBtn = document.querySelector('.spf-tool_submit');
+    this.domainInput = document.querySelector('.spf-tool_input');
 
     // Setup Event Listeners
-    document.querySelector('.spf-tool_form').addEventListener('submit', this.checkSpfRecord);
+    this.form.addEventListener('submit', this.checkSpfRecord);
 
     Array.prototype.forEach.call(document.querySelectorAll('.spf-tool_restart'), function(link) {
       link.addEventListener('click', SpfTool.resetTool);
@@ -65,15 +71,16 @@ var SpfTool = {
   checkSpfRecord: function(event) {
     event.preventDefault();
 
-    document.querySelector('.spf-tool_submit').setAttribute('disabled', 'disabled');
-    document.querySelector('.spf-tool_input').setAttribute('disabled', 'disabled');
+    SpfTool.submitBtn.setAttribute('disabled', 'disabled');
+    SpfTool.domainInput.setAttribute('disabled', 'disabled');
 
     // Remove any errors.
-    if (document.querySelector('.spf-tool_errors')) {
-      document.querySelector('.spf-tool_errors').remove();
+    var errorsContainer = document.querySelector('.spf-tool_errors');
+    if (errorsContainer) {
+      errorsContainer.remove();
     }
 
-    var domain = document.querySelector('.spf-tool_input').value;
+    var domain = SpfTool.domainInput.value;
 
     // Make a request to check the DNS.
     var request = new XMLHttpRequest();
@@ -96,9 +103,9 @@ var SpfTool = {
    * @return {undefined}
    */
   handleApiSuccess: function() {
-    document.querySelector('.spf-tool_submit').removeAttribute('disabled');
-    document.querySelector('.spf-tool_input').removeAttribute('disabled');
-    document.querySelector('.spf-tool_input').value = '';
+    SpfTool.submitBtn.removeAttribute('disabled');
+    SpfTool.domainInput.removeAttribute('disabled');
+    SpfTool.domainInput.value = '';
 
     var result = JSON.parse(this.responseText);
 
@@ -116,8 +123,8 @@ var SpfTool = {
    * @return {undefined}
    */
   handleApiError: function() {
-    document.querySelector('.spf-tool_submit').removeAttribute('disabled');
-    document.querySelector('.spf-tool_input').removeAttribute('disabled');
+    SpfTool.submitBtn.removeAttribute('disabled');
+    SpfTool.domainInput.removeAttribute('disabled');
 
     var result = JSON.parse(this.responseText);
     SpfTool.showErrors(result.errors);
@@ -130,9 +137,7 @@ var SpfTool = {
    * @return {undefined}
    */
   showErrors: function(errors) {
-    var errorsContainer = document.querySelector('.spf-tool_errors'),
-        form = document.querySelector('.spf-tool_form'),
-        input = document.querySelector('.spf-tool_input');
+    var errorsContainer = document.querySelector('.spf-tool_errors');
 
     if (errorsContainer) {
       errorsContainer.remove();
@@ -147,7 +152,7 @@ var SpfTool = {
       errorList.appendChild(item);
     });
 
-    form.insertBefore(errorList, input);
+    SpfTool.form.insertBefore(errorList, SpfTool.domainInput);
 
     SpfTool.showPane('start');
   },

--- a/html/src/javascripts/WORK_HERE.js
+++ b/html/src/javascripts/WORK_HERE.js
@@ -1,1 +1,133 @@
 /* ----------------- Write your code here ---------------- */
+
+const DNS_ENDPOINT = 'https://tranquil-stream-29919.herokuapp.com/update-spf';
+const SERVICE_SPF = 'spf.mtasv.net';
+
+var SpfTool = {
+
+  panes: null,
+
+
+  /**
+   * Initialise the SPF tool.
+   *
+   * @return {undefined}
+   */
+  init: function() {
+    // Find the panes.
+    this.panes = document.querySelectorAll('.spf-tool_pane');
+
+    // Setup Event Listeners
+    document.querySelector('.spf-tool_form').addEventListener('submit', this.checkSpfRecord);
+  },
+
+
+  /**
+   * Display a pane.
+   *
+   * @param  {String} pane The target pane.
+   * @return {undefined}
+   */
+  showPane: function(pane) {
+    Array.prototype.forEach.call(this.panes, function(ele) {
+      if (ele.classList.contains('spf-tool_pane--' + pane)) {
+        return ele.classList.add('spf-tool_pane--visible');
+      }
+
+      return ele.classList.remove('spf-tool_pane--visible');
+    });
+  },
+
+  /**.
+   * Check the DNS records to see if an SPF record needs to be added or
+   * modified.
+   *
+   * This hits a simple node service I built:
+   * https://github.com/matt-west/spf-web-service
+   *
+   * @param {Event} event   The form submission event.
+   * @return {undefined}
+   */
+  checkSpfRecord: function(event) {
+    event.preventDefault();
+
+    var domain = document.querySelector('.spf-tool_input').value;
+
+    // Basic input validation
+    if (!domain || !domain.replace(/\s/g, '').length) {
+      alert('Please specify a domain name'); // TODO: Display validation message.
+      return;
+    }
+
+    // Show a loading state.
+    SpfTool.showPane('loading');
+
+    // Make a requet to check the DNS.
+    var request = new XMLHttpRequest();
+
+    request.addEventListener('load', SpfTool.handleApiSuccess);
+    request.addEventListener('error', SpfTool.handleApiError);
+    request.addEventListener('abort', SpfTool.handleApiError);
+
+    request.open('POST', DNS_ENDPOINT);
+    request.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+    request.send(JSON.stringify({
+      domain: domain,
+      service_spf: SERVICE_SPF
+    }));
+
+  },
+
+  /**
+   * Handle successful requests to the API.
+   *
+   * @return {undefined}
+   */
+  handleApiSuccess: function() {
+    var result = JSON.parse(this.responseText);
+
+    if (this.status !== 200) {
+      SpfTool.showErrors(result.errors);
+      return;
+    }
+
+    var result = JSON.parse(this.responseText);
+
+    switch(result.operation) {
+      case 'create':
+
+        break;
+      case 'modify':
+
+        break;
+      case 'existing':
+
+        break;
+    }
+
+  },
+
+  /**
+   * Handle requests to the API that err.
+   *
+   * @return {undefined}
+   */
+  handleApiError: function() {
+    var result = JSON.parse(this.responseText);
+    SpfTool.showErrors(result.errors);
+  },
+
+  /**
+   * Display API errors to the user.
+   *
+   * @param  {Array} errors  A collection of error messages.
+   * @return {undefined}
+   */
+  showErrors: function(errors) {
+    console.log(errors);
+    SpfTool.showPane('start');
+  }
+
+};
+
+SpfTool.init();

--- a/html/src/javascripts/WORK_HERE.js
+++ b/html/src/javascripts/WORK_HERE.js
@@ -66,6 +66,7 @@ var SpfTool = {
     event.preventDefault();
 
     document.querySelector('.spf-tool_submit').setAttribute('disabled', 'disabled');
+    document.querySelector('.spf-tool_input').setAttribute('disabled', 'disabled');
 
     // Remove any errors.
     if (document.querySelector('.spf-tool_errors')) {
@@ -87,8 +88,6 @@ var SpfTool = {
       domain: domain,
       service_spf: SERVICE_SPF
     }));
-
-    document.querySelector('.spf-tool_input').value = '';
   },
 
   /**
@@ -98,6 +97,8 @@ var SpfTool = {
    */
   handleApiSuccess: function() {
     document.querySelector('.spf-tool_submit').removeAttribute('disabled');
+    document.querySelector('.spf-tool_input').removeAttribute('disabled');
+    document.querySelector('.spf-tool_input').value = '';
 
     var result = JSON.parse(this.responseText);
 
@@ -116,6 +117,7 @@ var SpfTool = {
    */
   handleApiError: function() {
     document.querySelector('.spf-tool_submit').removeAttribute('disabled');
+    document.querySelector('.spf-tool_input').removeAttribute('disabled');
 
     var result = JSON.parse(this.responseText);
     SpfTool.showErrors(result.errors);

--- a/html/src/javascripts/WORK_HERE.js
+++ b/html/src/javascripts/WORK_HERE.js
@@ -51,9 +51,11 @@ var SpfTool = {
   showPane: function(pane) {
     Array.prototype.forEach.call(this.panes, function(ele) {
       if (ele.classList.contains('spf-tool_pane--' + pane)) {
+        ele.removeAttribute('aria-hidden');
         return ele.classList.add('spf-tool_pane--visible');
       }
 
+      ele.setAttribute('aria-hidden', 'true');
       return ele.classList.remove('spf-tool_pane--visible');
     });
   },

--- a/html/src/stylesheets/_WORK_HERE.scss
+++ b/html/src/stylesheets/_WORK_HERE.scss
@@ -1,1 +1,63 @@
 /* ----------------- Write your code here ---------------- */
+
+$g-border-radius: 3px;
+
+.spf-tool {
+  box-sizing: border-box;
+
+  max-width: 630px;
+  margin: 0 auto 70px;
+  padding: 30px;
+
+  background: $c-yellow;
+  border-radius: $g-border-radius;
+
+  &_pane {
+    display: none;
+
+    &--visible {
+      display: block;
+    }
+  }
+
+  &_title {
+    font-family: $f-rockwell;
+    font-size: $f-scale-big;
+    font-weight: normal;
+    line-height: 1.2;
+
+    margin: 0 0 .75em;
+  }
+
+  &_form {}
+
+  &_label {
+    display: block;
+    margin-bottom: 1em;
+  }
+
+  &_input {
+    box-sizing: border-box;
+
+    font-family: $f-sansserif;
+    font-size: $f-scale-big;
+
+    display: block;
+    width: 100%;
+    padding: 7px 15px;
+    margin-bottom: 1em;
+
+    border-radius: $g-border-radius;
+    border: 3px solid $c-dark;
+    outline: none;
+
+    &:focus {
+      border-color: $c-blue-dark;
+    }
+  }
+
+  &_submit {
+    color: #FFF;
+    text-shadow: 0 1px 1px $c-blue-darkest;
+  }
+}

--- a/html/src/stylesheets/_WORK_HERE.scss
+++ b/html/src/stylesheets/_WORK_HERE.scss
@@ -1,22 +1,39 @@
 /* ----------------- Write your code here ---------------- */
 
+$namespace: '.spf-tool';
+
 $g-border-radius: 3px;
 
-.spf-tool {
+#{$namespace} {
   box-sizing: border-box;
 
   max-width: 630px;
   margin: 0 auto 70px;
-  padding: 30px;
-
-  background: $c-yellow;
-  border-radius: $g-border-radius;
 
   &_pane {
     display: none;
+    background: $c-yellow;
+    border-radius: $g-border-radius;
+    padding: 2em;
 
     &--visible {
       display: block;
+    }
+
+    &--existing {
+      background: $c-mint-dark;
+      color: #FFF;
+
+      a,
+      a:link,
+      a:visited {
+        color: #FFF;
+
+        &:hover,
+        &:focus {
+          color: darken($c-mint-dark, 15%);
+        }
+      }
     }
   }
 
@@ -29,10 +46,24 @@ $g-border-radius: 3px;
     margin: 0 0 .75em;
   }
 
-  &_form {}
+  &_form {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  &_errors {
+    width: 100%;
+    margin: 0 0 1em 0;
+    border-radius: $g-border-radius;
+    background-color: $c-red;
+    color: #FFF;
+    padding: .7em 1em;
+    list-style: none;
+  }
 
   &_label {
     display: block;
+    width: 100%;
     margin-bottom: 1em;
   }
 
@@ -40,24 +71,73 @@ $g-border-radius: 3px;
     box-sizing: border-box;
 
     font-family: $f-sansserif;
-    font-size: $f-scale-big;
+    font-size: $f-scale-bigger;
 
     display: block;
-    width: 100%;
-    padding: 7px 15px;
-    margin-bottom: 1em;
+    flex-grow: 4;
+    padding: .45em .9em;
 
     border-radius: $g-border-radius;
-    border: 3px solid $c-dark;
+    border: 1px solid $c-yellow-medium;
+    box-shadow: 0 1px 2px rgba(#000, .06) inset;
     outline: none;
 
     &:focus {
-      border-color: $c-blue-dark;
+      border-color: $c-yellow-dark;
     }
   }
 
   &_submit {
+    flex-grow: 1;
     color: #FFF;
     text-shadow: 0 1px 1px $c-blue-darkest;
+    margin-left: 1em;
+  }
+
+  &_instruction {
+    font-weight: 500;
+    background-color: $c-slate-darkest;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUiIGhlaWdodD0iMTUiIHZpZXdCb3g9IjAgMCAxNSAxNSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+YXJyb3ctc21hbGw8L3RpdGxlPjxwYXRoIGQ9Ik0xLjEzMyA3LjI2OGgxMi4yOG0uMzU1IDBMNy45NiAxMy4wNzZtNS44MDgtNS44MDhMNy45NiAxLjQ2IiBzdHJva2U9IiNGRkUwMDAiIHN0cm9rZS13aWR0aD0iMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PC9zdmc+);
+    background-repeat: no-repeat;
+    background-position: 1em 52%;
+    background-size: .8em .8em;
+
+    border-radius: $g-border-radius $g-border-radius 0 0;
+    margin: 0;
+    padding: .6em 1em .6em 2.5em;
+    color: #FFF;
+  }
+
+  &_code {
+    border-radius: 0 0 $g-border-radius $g-border-radius;
+    background-color: $c-slate;
+    color: #FFF;
+    padding: 1em;
+    margin-bottom: 1em;
+  }
+
+  &_restart {
+    float: right;
+    margin-top: .45em;
+    color: $c-page-tc;
+
+    &:link,
+    &:visited {
+      color: $c-page-tc;
+    }
+
+    &:hover,
+    &:focus {
+      color: $c-blue;
+    }
+
+    #{$namespace}_pane--existing & {
+      float: none;
+
+      &:link,
+      &:visited {
+        color: #FFF;
+      }
+    }
   }
 }

--- a/html/src/stylesheets/_WORK_HERE.scss
+++ b/html/src/stylesheets/_WORK_HERE.scss
@@ -7,14 +7,21 @@ $g-border-radius: 3px;
 #{$namespace} {
   box-sizing: border-box;
 
-  max-width: 630px;
   margin: 0 auto 70px;
+
+  @include medium {
+    padding: 0 35px;
+  }
+
+  @include large {
+    max-width: 630px;
+    padding: 0;
+  }
 
   &_pane {
     display: none;
     background: $c-yellow;
-    border-radius: $g-border-radius;
-    padding: 2em;
+    padding: 1.5em;
 
     &--visible {
       display: block;
@@ -35,6 +42,11 @@ $g-border-radius: 3px;
         }
       }
     }
+
+    @include medium {
+      padding: 2em;
+      border-radius: $g-border-radius;
+    }
   }
 
   &_title {
@@ -47,8 +59,11 @@ $g-border-radius: 3px;
   }
 
   &_form {
-    display: flex;
-    flex-wrap: wrap;
+
+    @include small {
+      display: flex;
+      flex-wrap: wrap;
+    }
   }
 
   &_errors {
@@ -74,8 +89,9 @@ $g-border-radius: 3px;
     font-size: $f-scale-bigger;
 
     display: block;
-    flex-grow: 4;
+    width: 100%;
     padding: .45em .9em;
+    margin-bottom: 1em;
 
     border-radius: $g-border-radius;
     border: 1px solid $c-yellow-medium;
@@ -85,13 +101,22 @@ $g-border-radius: 3px;
     &:focus {
       border-color: $c-yellow-dark;
     }
+
+    @include small {
+      width: auto;
+      flex-grow: 4;
+      margin-bottom: 0;
+    }
   }
 
   &_submit {
-    flex-grow: 1;
     color: #FFF;
     text-shadow: 0 1px 1px $c-blue-darkest;
-    margin-left: 1em;
+
+    @include small {
+      flex-grow: 1;
+      margin-left: 1em;
+    }
   }
 
   &_instruction {
@@ -117,8 +142,8 @@ $g-border-radius: 3px;
   }
 
   &_restart {
-    float: right;
-    margin-top: .45em;
+    display: block;
+    margin-top: 1em;
     color: $c-page-tc;
 
     &:link,
@@ -138,6 +163,12 @@ $g-border-radius: 3px;
       &:visited {
         color: #FFF;
       }
+    }
+
+    @include small {
+      float: right;
+      display: inline-block;
+      margin-top: .45em;
     }
   }
 }

--- a/html/src/stylesheets/_variables.scss
+++ b/html/src/stylesheets/_variables.scss
@@ -66,7 +66,7 @@ $c-popup:               #303030;
 $c-page-bg:             #FFF;
 $c-page-tc:             $c-slate-darkest;
 
-  // Links
+// Links
 
 $c-link:                $c-blue-dark;
 $c-visited:             desaturate(mix($c-link, $c-base, 50%), 25%);

--- a/html/stylesheets/postmark.css
+++ b/html/stylesheets/postmark.css
@@ -3697,36 +3697,92 @@ pre[class*='language-'] {
 .spf-tool {
   box-sizing: border-box;
   max-width: 630px;
-  margin: 0 auto 70px;
-  padding: 30px;
-  background: #FFDE00;
-  border-radius: 3px; }
+  margin: 0 auto 70px; }
   .spf-tool_pane {
-    display: none; }
+    display: none;
+    background: #FFDE00;
+    border-radius: 3px;
+    padding: 2em; }
     .spf-tool_pane--visible {
       display: block; }
+    .spf-tool_pane--existing {
+      background: #35A572;
+      color: #FFF; }
+      .spf-tool_pane--existing a,
+      .spf-tool_pane--existing a:link,
+      .spf-tool_pane--existing a:visited {
+        color: #FFF; }
+        .spf-tool_pane--existing a:hover, .spf-tool_pane--existing a:focus,
+        .spf-tool_pane--existing a:link:hover,
+        .spf-tool_pane--existing a:link:focus,
+        .spf-tool_pane--existing a:visited:hover,
+        .spf-tool_pane--existing a:visited:focus {
+          color: #226b4a; }
   .spf-tool_title {
     font-family: "Rockwell W01", "Helvetica Neue", Arial, Helvetica, sans-serif;
     font-size: 1.35em;
     font-weight: normal;
     line-height: 1.2;
     margin: 0 0 .75em; }
+  .spf-tool_form {
+    display: flex;
+    flex-wrap: wrap; }
+  .spf-tool_errors {
+    width: 100%;
+    margin: 0 0 1em 0;
+    border-radius: 3px;
+    background-color: #D25050;
+    color: #FFF;
+    padding: .7em 1em;
+    list-style: none; }
   .spf-tool_label {
     display: block;
+    width: 100%;
     margin-bottom: 1em; }
   .spf-tool_input {
     box-sizing: border-box;
     font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
-    font-size: 1.35em;
+    font-size: 1.125em;
     display: block;
-    width: 100%;
-    padding: 7px 15px;
-    margin-bottom: 1em;
+    flex-grow: 4;
+    padding: .45em .9em;
     border-radius: 3px;
-    border: 3px solid #333;
+    border: 1px solid #E5C700;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
     outline: none; }
     .spf-tool_input:focus {
-      border-color: #006EB3; }
+      border-color: #760; }
   .spf-tool_submit {
+    flex-grow: 1;
     color: #FFF;
-    text-shadow: 0 1px 1px #004775; }
+    text-shadow: 0 1px 1px #004775;
+    margin-left: 1em; }
+  .spf-tool_instruction {
+    font-weight: 500;
+    background-color: #22252B;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUiIGhlaWdodD0iMTUiIHZpZXdCb3g9IjAgMCAxNSAxNSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+YXJyb3ctc21hbGw8L3RpdGxlPjxwYXRoIGQ9Ik0xLjEzMyA3LjI2OGgxMi4yOG0uMzU1IDBMNy45NiAxMy4wNzZtNS44MDgtNS44MDhMNy45NiAxLjQ2IiBzdHJva2U9IiNGRkUwMDAiIHN0cm9rZS13aWR0aD0iMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PC9zdmc+);
+    background-repeat: no-repeat;
+    background-position: 1em 52%;
+    background-size: .8em .8em;
+    border-radius: 3px 3px 0 0;
+    margin: 0;
+    padding: .6em 1em .6em 2.5em;
+    color: #FFF; }
+  .spf-tool_code {
+    border-radius: 0 0 3px 3px;
+    background-color: #353942;
+    color: #FFF;
+    padding: 1em;
+    margin-bottom: 1em; }
+  .spf-tool_restart {
+    float: right;
+    margin-top: .45em;
+    color: #22252B; }
+    .spf-tool_restart:link, .spf-tool_restart:visited {
+      color: #22252B; }
+    .spf-tool_restart:hover, .spf-tool_restart:focus {
+      color: #007DCC; }
+    .spf-tool_pane--existing .spf-tool_restart {
+      float: none; }
+      .spf-tool_pane--existing .spf-tool_restart:link, .spf-tool_pane--existing .spf-tool_restart:visited {
+        color: #FFF; }

--- a/html/stylesheets/postmark.css
+++ b/html/stylesheets/postmark.css
@@ -3696,13 +3696,18 @@ pre[class*='language-'] {
 /* ----------------- Write your code here ---------------- */
 .spf-tool {
   box-sizing: border-box;
-  max-width: 630px;
   margin: 0 auto 70px; }
+  @media only screen and (min-width: 750px) {
+    .spf-tool {
+      padding: 0 35px; } }
+  @media only screen and (min-width: 1020px) {
+    .spf-tool {
+      max-width: 630px;
+      padding: 0; } }
   .spf-tool_pane {
     display: none;
     background: #FFDE00;
-    border-radius: 3px;
-    padding: 2em; }
+    padding: 1.5em; }
     .spf-tool_pane--visible {
       display: block; }
     .spf-tool_pane--existing {
@@ -3718,15 +3723,20 @@ pre[class*='language-'] {
         .spf-tool_pane--existing a:visited:hover,
         .spf-tool_pane--existing a:visited:focus {
           color: #226b4a; }
+    @media only screen and (min-width: 750px) {
+      .spf-tool_pane {
+        padding: 2em;
+        border-radius: 3px; } }
   .spf-tool_title {
     font-family: "Rockwell W01", "Helvetica Neue", Arial, Helvetica, sans-serif;
     font-size: 1.35em;
     font-weight: normal;
     line-height: 1.2;
     margin: 0 0 .75em; }
-  .spf-tool_form {
-    display: flex;
-    flex-wrap: wrap; }
+  @media only screen and (min-width: 480px) {
+    .spf-tool_form {
+      display: flex;
+      flex-wrap: wrap; } }
   .spf-tool_errors {
     width: 100%;
     margin: 0 0 1em 0;
@@ -3744,19 +3754,27 @@ pre[class*='language-'] {
     font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
     font-size: 1.125em;
     display: block;
-    flex-grow: 4;
+    width: 100%;
     padding: .45em .9em;
+    margin-bottom: 1em;
     border-radius: 3px;
     border: 1px solid #E5C700;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06) inset;
     outline: none; }
     .spf-tool_input:focus {
       border-color: #760; }
+    @media only screen and (min-width: 480px) {
+      .spf-tool_input {
+        width: auto;
+        flex-grow: 4;
+        margin-bottom: 0; } }
   .spf-tool_submit {
-    flex-grow: 1;
     color: #FFF;
-    text-shadow: 0 1px 1px #004775;
-    margin-left: 1em; }
+    text-shadow: 0 1px 1px #004775; }
+    @media only screen and (min-width: 480px) {
+      .spf-tool_submit {
+        flex-grow: 1;
+        margin-left: 1em; } }
   .spf-tool_instruction {
     font-weight: 500;
     background-color: #22252B;
@@ -3775,8 +3793,8 @@ pre[class*='language-'] {
     padding: 1em;
     margin-bottom: 1em; }
   .spf-tool_restart {
-    float: right;
-    margin-top: .45em;
+    display: block;
+    margin-top: 1em;
     color: #22252B; }
     .spf-tool_restart:link, .spf-tool_restart:visited {
       color: #22252B; }
@@ -3786,3 +3804,8 @@ pre[class*='language-'] {
       float: none; }
       .spf-tool_pane--existing .spf-tool_restart:link, .spf-tool_pane--existing .spf-tool_restart:visited {
         color: #FFF; }
+    @media only screen and (min-width: 480px) {
+      .spf-tool_restart {
+        float: right;
+        display: inline-block;
+        margin-top: .45em; } }

--- a/html/stylesheets/postmark.css
+++ b/html/stylesheets/postmark.css
@@ -3694,3 +3694,39 @@ pre[class*='language-'] {
     transition: all .5s ease; }
 
 /* ----------------- Write your code here ---------------- */
+.spf-tool {
+  box-sizing: border-box;
+  max-width: 630px;
+  margin: 0 auto 70px;
+  padding: 30px;
+  background: #FFDE00;
+  border-radius: 3px; }
+  .spf-tool_pane {
+    display: none; }
+    .spf-tool_pane--visible {
+      display: block; }
+  .spf-tool_title {
+    font-family: "Rockwell W01", "Helvetica Neue", Arial, Helvetica, sans-serif;
+    font-size: 1.35em;
+    font-weight: normal;
+    line-height: 1.2;
+    margin: 0 0 .75em; }
+  .spf-tool_label {
+    display: block;
+    margin-bottom: 1em; }
+  .spf-tool_input {
+    box-sizing: border-box;
+    font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
+    font-size: 1.35em;
+    display: block;
+    width: 100%;
+    padding: 7px 15px;
+    margin-bottom: 1em;
+    border-radius: 3px;
+    border: 3px solid #333;
+    outline: none; }
+    .spf-tool_input:focus {
+      border-color: #006EB3; }
+  .spf-tool_submit {
+    color: #FFF;
+    text-shadow: 0 1px 1px #004775; }


### PR DESCRIPTION
This PR adds a tool to the bottom of the SPF guide to help readers update their DNS records correctly.

Screencast walkthrough is available here: http://quick.as/R95ia51X
